### PR TITLE
Support getting TOP N rows from table

### DIFF
--- a/AzTable.psd1
+++ b/AzTable.psd1
@@ -19,7 +19,7 @@ Description = 'Sample functions to add/retrieve/update entities on Azure Storage
 HelpInfoUri = 'https://paulomarquesc.github.io/working-with-azure-storage-tables-from-powershell/'
 
 # Version number of this module
-ModuleVersion = '2.0.2'
+ModuleVersion = '2.0.3'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '4.0'

--- a/AzureRmStorageTable.psd1
+++ b/AzureRmStorageTable.psd1
@@ -19,7 +19,7 @@ Description = 'Sample functions to add/retrieve/update entities on Azure Storage
 HelpInfoUri = 'https://paulomarquesc.github.io/working-with-azure-storage-tables-from-powershell/'
 
 # Version number of this module
-ModuleVersion = '2.0.2'
+ModuleVersion = '2.0.3'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '4.0'

--- a/docs/Get-AzTableRow.md
+++ b/docs/Get-AzTableRow.md
@@ -250,7 +250,7 @@ Accept wildcard characters: False
 ```
 
 ### -Top
-Custom Filter string (byCustomFilter parameter set)
+How many rows to return. If not specified, all rows are returned. Rough equivalent of SQL SELECT TOP(N) FROM...
 
 ```yaml
 Type: Int32

--- a/docs/Get-AzTableRow.md
+++ b/docs/Get-AzTableRow.md
@@ -38,6 +38,11 @@ Get-AzTableRow [-Table <Object>] [-PartitionKey <String>] -RowKey <String> [<Com
 Get-AzTableRow [-Table <Object>] -PartitionKey <String> [<CommonParameters>]
 ```
 
+### topNbyPartitionKey
+```powershell
+Get-AzTableRow [-Table <Object>] -PartitionKey <String> [<CommonParameters>] -Top 1000
+```
+
 ### GetAll
 ```powershell
 Get-AzTableRow -Table <Object> [<CommonParameters>]
@@ -53,6 +58,9 @@ Used to return entities from a table with several options, this replaces all oth
 # Getting all rows
 Get-AzTableRow -Table $Table
 
+# Getting top 1000 rows from table
+Get-AzTableRow -Table $Table -Top 1000
+
 # Getting rows by partition key
 Get-AzTableRow -Table $table -partitionKey NewYorkSite
 
@@ -67,6 +75,7 @@ Get-AzTableRow -Table $Table -ColumnName "osVersion" -value "Windows NT 4" -oper
 
 # Getting rows using Custom Filter
 Get-AzTableRow -Table $Table -CustomFilter "(osVersion eq 'Windows NT 4') and (computerName eq 'COMP07')"
+
 ```
 
 ## PARAMETERS
@@ -236,6 +245,21 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Top
+Custom Filter string (byCustomFilter parameter set)
+
+```yaml
+Type: Int32
+Parameter Sets:
+Aliases:
+
+Required: False
+Position: Named
+Default value: [Int32]::MaxValue
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Hi Paulo,
I'm working with very large tables (100K+ rows) and just need to process all records in the table. Getting all rows at once is not practical, and I don't know content of the table, so limiting by custom filter or querying by partition key is not option here.
So I updated the module to be able to specify # of records to return from query, and call into table iteratively until all rows are processed.
I guess this may get handy to other people as well, so I'm proposing this to get included into your version

Regards,
Jiri