### PR TITLE
Add -SelectColumns parameter to Get-AzTableRow command

### DIFF
--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -480,6 +480,8 @@ function Get-AzTableRow
 		Identifies the table partition (byPartitionKey and byPartRowKeys parameter sets)
 	.PARAMETER RowKey
 		Identifies the row key in the partition (byPartRowKeys parameter set)
+	.PARAMETER SelectColumns
+		Names of the properties to return for each entity
 	.PARAMETER ColumnName
 		Column name to compare the value to (byColummnString and byColummnGuid parameter sets)
 	.PARAMETER Value
@@ -493,6 +495,10 @@ function Get-AzTableRow
 	.EXAMPLE
 		# Getting all rows
 		Get-AzTableRow -Table $Table
+
+		# Getting specific properties for all rows
+		$columns = ('osVersion', 'computerName')
+		Get-AzTableRow -Table $Table -SelectColumns $columns
 
 		# Getting rows by partition key
 		Get-AzTableRow -Table $table -partitionKey NewYorkSite
@@ -519,6 +525,14 @@ function Get-AzTableRow
 		[Parameter(ParameterSetName="byColummnGuid")]
 		[Parameter(ParameterSetName="byCustomFilter")]
 		$Table,
+
+		[Parameter(ParameterSetName="GetAll")]
+		[Parameter(ParameterSetName="byPartitionKey")]
+		[Parameter(ParameterSetName="byPartRowKeys")]
+		[Parameter(ParameterSetName="byColummnString")]
+		[Parameter(ParameterSetName="byColummnGuid")]
+		[Parameter(ParameterSetName="byCustomFilter")]
+		[array]$SelectColumns,
 
 		[Parameter(Mandatory=$true,ParameterSetName="byPartitionKey")]
 		[Parameter(ParameterSetName="byPartRowKeys")]
@@ -593,6 +607,15 @@ function Get-AzTableRow
 	if (-not [string]::IsNullOrEmpty($Filter))
 	{
 		$TableQuery.FilterString = $Filter
+	}
+
+	# Selecting columns if specified
+	if ($null -ne $SelectColumns){
+		[string[]]$Cols = $SelectColumns
+		$ColumnsList = New-Object System.Collections.Generic.List[string]
+		$ColumnsList.AddRange($Cols)
+
+		$TableQuery.SelectColumns = $ColumnsList
 	}
 
 	# Getting results

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -480,7 +480,7 @@ function Get-AzTableRow
 		Identifies the table partition (byPartitionKey and byPartRowKeys parameter sets)
 	.PARAMETER RowKey
 		Identifies the row key in the partition (byPartRowKeys parameter set)
-	.PARAMETER SelectColumns
+	.PARAMETER SelectColumn
 		Names of the properties to return for each entity
 	.PARAMETER ColumnName
 		Column name to compare the value to (byColummnString and byColummnGuid parameter sets)
@@ -498,7 +498,7 @@ function Get-AzTableRow
 
 		# Getting specific properties for all rows
 		$columns = ('osVersion', 'computerName')
-		Get-AzTableRow -Table $Table -SelectColumns $columns
+		Get-AzTableRow -Table $Table -SelectColumn $columns
 
 		# Getting rows by partition key
 		Get-AzTableRow -Table $table -partitionKey NewYorkSite
@@ -532,7 +532,7 @@ function Get-AzTableRow
 		[Parameter(ParameterSetName="byColummnString")]
 		[Parameter(ParameterSetName="byColummnGuid")]
 		[Parameter(ParameterSetName="byCustomFilter")]
-		[array]$SelectColumns,
+		[System.Collections.Generic.List[string]]$SelectColumn,
 
 		[Parameter(Mandatory=$true,ParameterSetName="byPartitionKey")]
 		[Parameter(ParameterSetName="byPartRowKeys")]
@@ -610,12 +610,8 @@ function Get-AzTableRow
 	}
 
 	# Selecting columns if specified
-	if ($null -ne $SelectColumns){
-		[string[]]$Cols = $SelectColumns
-		$ColumnsList = New-Object System.Collections.Generic.List[string]
-		$ColumnsList.AddRange($Cols)
-
-		$TableQuery.SelectColumns = $ColumnsList
+	if ($null -ne $SelectColumn){
+		$TableQuery.SelectColumns = $SelectColumn
 	}
 
 	# Getting results

--- a/Tests/AzureRmStorageTable.Tests.ps1
+++ b/Tests/AzureRmStorageTable.Tests.ps1
@@ -156,7 +156,7 @@ Describe "AzureRmStorageTable" {
         It "Can it get specific columns for a specific row" {
             $entity = $null
             $expectedStringValue = "Windows 10"
-            $entity = Get-AzTableRow -Table $tableInsert -partitionKey $partitionKey -rowKey $rowKey -SelectColumns @('osVersion', 'computerName')
+            $entity = Get-AzTableRow -Table $tableInsert -partitionKey $partitionKey -rowKey $rowKey -SelectColumn @('osVersion', 'computerName')
             $entity.osVersion | Should be $expectedStringValue
             $entity.status | Should be $null
         }

--- a/Tests/AzureRmStorageTable.Tests.ps1
+++ b/Tests/AzureRmStorageTable.Tests.ps1
@@ -153,6 +153,14 @@ Describe "AzureRmStorageTable" {
             $entityList.Count | Should be $expectedRowCount
         }
 
+        It "Can it get specific columns for a specific row" {
+            $entity = $null
+            $expectedStringValue = "Windows 10"
+            $entity = Get-AzTableRow -Table $tableInsert -partitionKey $partitionKey -rowKey $rowKey -SelectColumns @('osVersion', 'computerName')
+            $entity.osVersion | Should be $expectedStringValue
+            $entity.status | Should be $null
+        }
+
         It "Can it get rows by partition key" {
             $entityList = $null
             $expectedRowCount = 4

--- a/docs/Get-AzTableRow.md
+++ b/docs/Get-AzTableRow.md
@@ -42,6 +42,10 @@ Get-AzTableRow [-Table <Object>] -PartitionKey <String> [<CommonParameters>]
 ```powershell
 Get-AzTableRow -Table <Object> [<CommonParameters>]
 ```
+### SelectColumns
+```powershell
+Get-AzTableRow -Table <Object> [<CommonParameters>] -SelectColumns [<array>]
+```
 
 ## DESCRIPTION
 Used to return entities from a table with several options, this replaces all other Get-AzTable<XYZ> cmdlets.
@@ -56,6 +60,9 @@ Get-AzTableRow -Table $Table
 # Getting rows by partition key
 Get-AzTableRow -Table $table -partitionKey NewYorkSite
 
+# Getting specific columns
+Get-AzTableRow -Table $table -partitionKey NewYorkSite -SelectColumns @('computerName', 'osVersion')
+
 # Getting rows by partition and row key
 Get-AzTableRow -Table $table -partitionKey NewYorkSite -rowKey "afc04476-bda0-47ea-a9e9-7c739c633815"
 
@@ -67,6 +74,7 @@ Get-AzTableRow -Table $Table -ColumnName "osVersion" -value "Windows NT 4" -oper
 
 # Getting rows using Custom Filter
 Get-AzTableRow -Table $Table -CustomFilter "(osVersion eq 'Windows NT 4') and (computerName eq 'COMP07')"
+
 ```
 
 ## PARAMETERS
@@ -92,6 +100,21 @@ Parameter Sets: GetAll
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SelectColumns
+Columns to be fetched by the query
+
+```yaml
+Type: Array
+Parameter Sets: byCustomFilter, byColummnGuid, byColummnString, byPartRowKeys, byPartitionKey
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/Get-AzTableRow.md
+++ b/docs/Get-AzTableRow.md
@@ -42,9 +42,9 @@ Get-AzTableRow [-Table <Object>] -PartitionKey <String> [<CommonParameters>]
 ```powershell
 Get-AzTableRow -Table <Object> [<CommonParameters>]
 ```
-### SelectColumns
+### SelectColumn
 ```powershell
-Get-AzTableRow -Table <Object> [<CommonParameters>] -SelectColumns [<array>]
+Get-AzTableRow -Table <Object> [<CommonParameters>] -SelectColumn [<string[]>]
 ```
 
 ## DESCRIPTION
@@ -61,7 +61,7 @@ Get-AzTableRow -Table $Table
 Get-AzTableRow -Table $table -partitionKey NewYorkSite
 
 # Getting specific columns
-Get-AzTableRow -Table $table -partitionKey NewYorkSite -SelectColumns @('computerName', 'osVersion')
+Get-AzTableRow -Table $table -partitionKey NewYorkSite -SelectColumn @('computerName', 'osVersion')
 
 # Getting rows by partition and row key
 Get-AzTableRow -Table $table -partitionKey NewYorkSite -rowKey "afc04476-bda0-47ea-a9e9-7c739c633815"
@@ -106,11 +106,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SelectColumns
+### -SelectColumn
 Columns to be fetched by the query
 
 ```yaml
-Type: Array
+Type: System.Collections.Generic.List[string]
 Parameter Sets: byCustomFilter, byColummnGuid, byColummnString, byPartRowKeys, byPartitionKey
 Aliases:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -200,7 +200,7 @@ Result
 
 ```powershell
 $Columns = @('computerName','osVersion')
-Get-AzTableRow -Table $table -SelectColumns $Columns
+Get-AzTableRow -Table $table -SelectColumn $Columns
 ```
 
 #### Getting rows/entities by partition key

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,6 +196,13 @@ Result
 
 ![result all](./media/image392.png)
 
+#### Getting specific columns only
+
+```powershell
+$Columns = @('computerName','osVersion')
+Get-AzTableRow -Table $table -SelectColumns $Columns
+```
+
 #### Getting rows/entities by partition key
 
 ```powershell


### PR DESCRIPTION
Adding the -SelectColumns parameter to specify which columns the query should return. This can result in significant performance benefits for tables with many columns when only a subset is needed.