### PR TITLE
Features/batch

### DIFF
--- a/AzTable.psd1
+++ b/AzTable.psd1
@@ -42,7 +42,9 @@ FunctionsToExport = @(  'Add-AzTableRow',
                         'Get-AzTableRowByCustomFilter',
                         'Update-AzTableRow',
                         'Remove-AzTableRow',
-                        'Get-AzTableTable'
+                        'Get-AzTableTable',
+                        'New-AzTableBatch',
+                        'Save-AzTableBatch'
                         )
 
 VariablesToExport = ''

--- a/AzTable.psd1
+++ b/AzTable.psd1
@@ -44,7 +44,7 @@ FunctionsToExport = @(  'Add-AzTableRow',
                         'Remove-AzTableRow',
                         'Get-AzTableTable',
                         'New-AzTableBatch',
-                        'Save-AzTableBatch'
+                        'Invoke-AzTableBatch'
                         )
 
 VariablesToExport = ''

--- a/AzureRmStorageTable.psd1
+++ b/AzureRmStorageTable.psd1
@@ -42,7 +42,9 @@
                             'Get-AzTableRowByCustomFilter',
                             'Update-AzTableRow',
                             'Remove-AzTableRow',
-                            'Get-AzTableTable'
+                            'Get-AzTableTable',
+                            'New-AzTableBatch',
+                            'Invoke-AzTableBatch'
                             )
     
     VariablesToExport = ''

--- a/AzureRmStorageTable.psd1
+++ b/AzureRmStorageTable.psd1
@@ -42,9 +42,7 @@
                             'Get-AzTableRowByCustomFilter',
                             'Update-AzTableRow',
                             'Remove-AzTableRow',
-                            'Get-AzTableTable',
-                            'New-AzTableBatch',
-                            'Invoke-AzTableBatch'
+                            'Get-AzTableTable'
                             )
     
     VariablesToExport = ''

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -134,6 +134,11 @@ function New-AzTableBatch
 		$Operations
 	)
 
+	if ($null -eq $Operations) {
+		# Will return null without this line
+		return New-Object -TypeName "Microsoft.Azure.Cosmos.Table.TableBatchOperation"
+	}
+
 	$batchOperation = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.TableBatchOperation" 
 
 	foreach ($operation in $Operations)

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -115,13 +115,34 @@ function New-AzTableBatch
     .EXAMPLE
         # Create batch
         $Batch = New-AzTableBatch
+	.EXAMPLE
+		# Create and populate batch operation
+		$entity1 = @{Partition="Partition1"; RowKey="1"; ExampleProperty="myprop"}
+		$entity2 = @{Partition="Partition1"; RowKey="2"; ExampleProperty="myprop2"}
+		$operation1 = [Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($entity1)
+		$operation2 = [Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($entity2)
+		$Batch = New-AzTableBatch -Operations @($operation1, $operation2)
     #>
-    param()
+	[CmdletBinding()]
+    param
+	(
+		[Parameter(Mandatory=$false)]
+		[AllowEmptyCollection()]
+		[Microsoft.Azure.Cosmos.Table.TableOperation[]]
+		$Operations
+	)
 
-    return New-Object -TypeName "Microsoft.Azure.Cosmos.Table.TableBatchOperation"
+	$batchOperation = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.TableBatchOperation" 
+
+	foreach ($operation in $Operations)
+	{
+		$batchOperation.Add($operation)
+	}
+
+    return $batchOperation
 }
 
-function Save-AzTableBatch
+function Invoke-AzTableBatch
 {
     <#
     .SYNOPSIS
@@ -314,11 +335,11 @@ function Add-AzTableRowBatch
 {
 	<#
 	.SYNOPSIS
-		Adds a row/entity to a specified table
+		Adds rows to a specified table
 	.DESCRIPTION
-		Adds a row/entity to a specified table
+		Adds rows to a specified table
 	.PARAMETER Table
-		Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entity will be added
+		Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entities will be added
 	.PARAMETER PartitionKey
 		Identifies the table partition
 	.PARAMETER RowKey
@@ -328,7 +349,7 @@ function Add-AzTableRowBatch
 	.PARAMETER UpdateExisting
 		Signalizes that command should update existing row, if such found by PartitionKey and RowKey. If not found, new row is added.
 	.EXAMPLE
-		# Adding a row
+		# Adding rows
 		Add-AzTableRow -Table $Table -PartitionKey $PartitionKey -RowKey ([guid]::NewGuid().tostring()) -property @{"firstName"="Paulo";"lastName"="Costa";"role"="presenter"}
 	#>
 	[CmdletBinding()]

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -117,11 +117,13 @@ function New-AzTableBatch
         $Batch = New-AzTableBatch
 	.EXAMPLE
 		# Create and populate batch operation
-		$entity1 = @{Partition="Partition1"; RowKey="1"; ExampleProperty="myprop"}
-		$entity2 = @{Partition="Partition1"; RowKey="2"; ExampleProperty="myprop2"}
+		$entity1 = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.DynamicTableEntity" -ArgumentList "Partition1", "1"
+		$entity1.Properties.Add("ExampleProperty", "myProp")
+		$entity2 = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.DynamicTableEntity" -ArgumentList "Partition1", "2"
+		$entity2.Properties.Add("ExampleProperty", "myProp2")
 		$operation1 = [Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($entity1)
 		$operation2 = [Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($entity2)
-		$Batch = New-AzTableBatch -Operations @($operation1, $operation2)
+		$batch = New-AzTableBatch -Operations @($operation1, $operation2)
     #>
 	[CmdletBinding()]
     param

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -107,6 +107,44 @@ function GetPSObjectFromEntity($entityList)
 
 }
 
+function New-AzTableBatch
+{
+    <#
+    .SYNOPSIS
+        Creates a new batch operation object.
+    .EXAMPLE
+        # Create batch
+        $Batch = New-AzTableBatch
+    #>
+    param()
+
+    return New-Object -TypeName "Microsoft.Azure.Cosmos.Table.TableBatchOperation"
+}
+
+function Save-AzTableBatch
+{
+    <#
+    .SYNOPSIS
+        Execute a batch operation against the specified table.
+    .PARAMETER Table
+        Table object of type Microsoft.Azure.Cosmos.Table.CloudTable to execute the batch upon.
+    .PARAMETER Batch
+        Cosmos Batch operation object of type Microsoft.Azure.Cosmos.Table.TableBatchOperation that has the entity operations to perform on the table.
+    .EXAMPLE
+        # Execute a batch operation
+        Save-AzTableBatch -Table $Table -Batch $Batch
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [Microsoft.Azure.Cosmos.Table.CloudTable]$Table,
+
+        [Parameter(Mandatory=$true)]
+        [Microsoft.Azure.Cosmos.Table.TableBatchOperation]$Batch
+    )
+
+    return $Table.ExecuteBatch($Batch)
+}
 
 function Get-AzTableTable
 {
@@ -214,6 +252,8 @@ function Add-AzTableRow
 		Adds a row/entity to a specified table
 	.PARAMETER Table
 		Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entity will be added
+	.PARAMETER Batch
+		Batch operation object of type Microsoft.Azure.Cosmos.Table.TableBatchOperation to add the entity into if provided.
 	.PARAMETER PartitionKey
 		Identifies the table partition
 	.PARAMETER RowKey
@@ -229,9 +269,12 @@ function Add-AzTableRow
 	[CmdletBinding()]
 	param
 	(
-		[Parameter(Mandatory=$true)]
+		[Parameter(ParameterSetName="Table", Mandatory=$true)]
 		$Table,
 		
+		[Parameter(ParameterSetName="Batch", Mandatory=$true)]
+		$Batch,
+
 		[Parameter(Mandatory=$true)]
 		[AllowEmptyString()]
         [String]$PartitionKey,
@@ -259,11 +302,25 @@ function Add-AzTableRow
 
     if ($UpdateExisting)
 	{
-		return ($Table.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::InsertOrReplace($entity)))
+		if ($PSCmdlet.ParameterSetName -eq "Batch")
+		{
+			$Batch.InsertOrReplace($entity)
+		}
+		else
+		{
+			return ($Table.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::InsertOrReplace($entity)))
+		}
 	}
 	else
 	{
-		return ($Table.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($entity)))
+		if ($PSCmdlet.ParameterSetName -eq "Batch")
+		{
+			$Batch.Insert($entity)
+		}
+		else
+		{
+			return ($Table.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::Insert($entity)))
+		}
 	}
 }
 

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -342,10 +342,8 @@ function Add-AzTableRowBatch
 		Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entities will be added
 	.PARAMETER PartitionKey
 		Identifies the table partition
-	.PARAMETER RowKey
-		Identifies a row within a partition
-	.PARAMETER Property
-		Hashtable with the columns that will be part of the entity. e.g. @{"firstName"="Paulo";"lastName"="Marques"}
+	.PARAMETER Entities
+		Hashtable array with the entities that will be 
 	.PARAMETER UpdateExisting
 		Signalizes that command should update existing row, if such found by PartitionKey and RowKey. If not found, new row is added.
 	.EXAMPLE

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -268,9 +268,9 @@ function Add-AzTableRow
 {
 	<#
 	.SYNOPSIS
-		Adds a row/entity to a specified table
+		Adds a row/entity to a specified table or batch operation
 	.DESCRIPTION
-		Adds a row/entity to a specified table
+		Adds a row/entity to a specified table or batch operation
 	.PARAMETER Table
 		Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entity will be added
 	.PARAMETER Batch
@@ -311,7 +311,7 @@ function Add-AzTableRow
         [String]$RowKey,
 
 		[Parameter(Mandatory=$false)]
-        [hashtable]$property,
+        [hashtable]$Property,
 		[Switch]$UpdateExisting
 	)
 
@@ -319,11 +319,11 @@ function Add-AzTableRow
 	$entity = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.DynamicTableEntity" -ArgumentList $PartitionKey, $RowKey
 
     # Adding the additional columns to the table entity
-	foreach ($prop in $property.Keys)
+	foreach ($prop in $Property.Keys)
 	{
 		if ($prop -ne "TableTimestamp")
 		{
-			$entity.Properties.Add($prop, $property.Item($prop))
+			$entity.Properties.Add($prop, $Property.Item($prop))
 		}
 	}
 
@@ -781,9 +781,9 @@ function Update-AzTableRow
 {
 	<#
 	.SYNOPSIS
-		Updates a table entity
+		Updates a table entity or batch operation
 	.DESCRIPTION
-		Updates a table entity. To work with this cmdlet, you need first retrieve an entity with one of the Get-AzTableRow cmdlets available
+		Updates a table entity or batch operation. To work with this cmdlet, you need first retrieve an entity with one of the Get-AzTableRow cmdlets available
 		and store in an object, change the necessary properties and then perform the update passing this modified entity back, through Pipeline or as argument.
 		Notice that this cmdlet accepts only one entity per execution.
 		This cmdlet cannot update Partition Key and/or RowKey because it uses those two values to locate the entity to update it, if this operation is required
@@ -821,22 +821,22 @@ function Update-AzTableRow
 		$Batch,
 
 		[Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-		$entity
+		$Entity
 	)
 
     # Only one entity at a time can be updated
     $updatedEntityList = @()
-    $updatedEntityList += $entity
+    $updatedEntityList += $Entity
 
     if ($updatedEntityList.Count -gt 1)
     {
         throw "Update operation can happen on only one entity at a time, not in a list/array of entities."
     }
 
-	$updatedEntity = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.DynamicTableEntity" -ArgumentList $entity.PartitionKey, $entity.RowKey
+	$updatedEntity = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.DynamicTableEntity" -ArgumentList $Entity.PartitionKey, $Entity.RowKey
 
 	# Iterating over PS Object properties to add to the updated entity
-	foreach ($prop in $entity.psobject.Properties)
+	foreach ($prop in $Entity.psobject.Properties)
 	{
 		if (($prop.name -ne "PartitionKey") -and ($prop.name -ne "RowKey") -and ($prop.name -ne "Timestamp") -and ($prop.name -ne "Etag") -and ($prop.name -ne "TableTimestamp"))
 		{
@@ -844,13 +844,13 @@ function Update-AzTableRow
 		}
 	}
 
-	$updatedEntity.ETag = $entity.Etag
-	$updatedEntity.Timestamp = $entity.TableTimestamp
+	$updatedEntity.ETag = $Entity.Etag
+	$updatedEntity.Timestamp = $Entity.TableTimestamp
 
 	
 	if ($PSCmdlet.ParameterSetName -eq "Batch")
 	{
-		$Batch.InsertOrMerge($entity)
+		$Batch.InsertOrMerge($updatedEntity)
 	}
 	else
 	{
@@ -913,7 +913,7 @@ function Remove-AzTableRow
 
 		[Parameter(ParameterSetName="Batch", Mandatory=$true)]
 		[Parameter(ParameterSetName="byEntityPSObjectObject",Mandatory=$true,ValueFromPipeline=$true)]
-		$entity,
+		$Entity,
 
 		[Parameter(ParameterSetName="byPartitionandRowKeys",Mandatory=$true)]
 		[AllowEmptyString()]
@@ -927,7 +927,7 @@ function Remove-AzTableRow
 	begin
 	{
 		$updatedEntityList = @()
-		$updatedEntityList += $entity
+		$updatedEntityList += $Entity
 
 		if ($updatedEntityList.Count -gt 1)
 		{
@@ -941,8 +941,8 @@ function Remove-AzTableRow
 	{
 		if ($PSCmdlet.ParameterSetName -ne "byPartitionandRowKeys")
 		{
-			$PartitionKey = $entity.PartitionKey
-			$RowKey = $entity.RowKey
+			$PartitionKey = $Entity.PartitionKey
+			$RowKey = $Entity.RowKey
 		}
 
 		$TableQuery = New-Object -TypeName "Microsoft.Azure.Cosmos.Table.TableQuery"

--- a/AzureRmStorageTableCoreHelper.psm1
+++ b/AzureRmStorageTableCoreHelper.psm1
@@ -985,7 +985,7 @@ function Remove-AzTableRow
 
 	process
 	{
-		if ($PSCmdlet.ParameterSetName -eq "byEntityPSObjectObject")
+		if ($PSCmdlet.ParameterSetName -ne "byPartitionandRowKeys")
 		{
 			$PartitionKey = $entity.PartitionKey
 			$RowKey = $entity.RowKey
@@ -1004,13 +1004,23 @@ function Remove-AzTableRow
 			$entityToDelete.PartitionKey = $itemToDelete.PartitionKey
 			$entityToDelete.RowKey = $itemToDelete.RowKey
 
-			$Results += $Table.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::Delete($entityToDelete))
+			if ($PSCmdlet.ParameterSetName -eq "Batch")
+			{
+				$Batch.Delete($entityToDelete)
+			}
+			else
+			{
+				$Results += $Table.Execute([Microsoft.Azure.Cosmos.Table.TableOperation]::Delete($entityToDelete))	
+			}
 		}
 	}
 
 	end
 	{
-		return ,$Results
+		if ($PSCmdlet.ParameterSetName -ne "Batch")
+		{
+			return ,$Results
+		}
 	}
 }
 

--- a/Tests/AzureRmStorageTable.Tests.ps1
+++ b/Tests/AzureRmStorageTable.Tests.ps1
@@ -153,7 +153,16 @@ Describe "AzureRmStorageTable" {
         }
 
         It "Can add multiple entities with a batch operation" {
+            $batch = New-AzTableBatch
+            $PK = [guid]::NewGuid().Guid
 
+            $property1Content = "COMP01"
+            $property2Content = "Linux"
+
+            Add-AzTableRow -Batch $batch -RowKey ([guid]::NewGuid().tostring()) -PartitionKey $PK -Property @{ "computerName" = $property1Content; "osVersion" = $property2Content }
+            Add-AzTableRow -Batch $batch -RowKey ([guid]::NewGuid().tostring()) -PartitionKey $PK -Property @{ "computerName" = $property1Content; "osVersion" = $property2Content }
+
+            $batch.Count | Should -Be 2
         }
     }
 

--- a/Tests/AzureRmStorageTable.Tests.ps1
+++ b/Tests/AzureRmStorageTable.Tests.ps1
@@ -481,6 +481,22 @@ Describe "AzureRmStorageTable" {
                 }
             }
         }
+
+        It "Can delete all entries in a table with different partitions" {
+            $batch = New-AzTableBatch
+
+            $all = Get-AzTableRow -Table $tableInsert
+
+            foreach ($entity in $all) {
+                $entity | Remove-AzTableRow -Batch $batch
+            }
+
+            Invoke-AzTableBatch -Table $tableInsert -Batch $batch
+
+            $check = Get-AzTableRow -Table $tableInsert
+
+            $check | Should -BeNullOrEmpty
+        }
     }
 
     AfterAll { 

--- a/Tests/AzureRmStorageTable.Tests.ps1
+++ b/Tests/AzureRmStorageTable.Tests.ps1
@@ -15,9 +15,12 @@ $uniqueString = [string]::Format("s{0}{1}",("{0:X}" -f (([guid]::NewGuid()).Guid
 $resourceGroup = "$uniqueString-rg"
 
 $GetAzTableTableCmdtTableName = "TestTable"
+Write-Host $GetAzTableTableCmdtTableName
 
 Describe "AzureRmStorageTable" {
     BeforeAll {
+        $GetAzTableTableCmdtTableName = "TestTable"
+
         if ($PSCmdlet.ParameterSetName -ne "AzureStorage")
         {
             # Storage Emulator
@@ -39,7 +42,7 @@ Describe "AzureRmStorageTable" {
         foreach ($tableName in $tableNames)
         {
             Write-Host -for DarkGreen "   Creating Storage Table $($tableName)"
-            $Table = Invoke-Expression("Get-AzTableTable -table `$tableName $GetTableCommand")
+            $Table = Invoke-Expression("Get-AzTableTable -TableName `$tableName $GetTableCommand")
 
             Write-Host -for Green "      Created Table $($table | out-string)"
             $tables.Add($table)
@@ -51,13 +54,14 @@ Describe "AzureRmStorageTable" {
         $GetTableCommand=@{$true = "-UseStorageEmulator"; $false = "-ResourceGroup `$resourceGroup -StorageAccountName `$uniqueString"}[($PSCmdlet.ParameterSetName -ne "AzureStorage")]
 
         It "Can create a new table" {
-            $Table = Invoke-Expression("Get-AzTableTable -table `$GetAzTableTableCmdtTableName $GetTableCommand") 
-            $Table | Should not be $null
+            Write-Host "Get-AzTableTable -TableName $GetAzTableTableCmdtTableName $GetTableCommand"
+            $Table = Invoke-Expression("Get-AzTableTable -TableName `$GetAzTableTableCmdtTableName $GetTableCommand") 
+            $Table | Should -Not -Be $null
         }
 
         It "Can open an existing table" {
-            $Table = Invoke-Expression("Get-AzTableTable -table `$GetAzTableTableCmdtTableName $GetTableCommand") 
-            $Table | Should not be $null
+            $Table = Invoke-Expression("Get-AzTableTable -TableName `$GetAzTableTableCmdtTableName $GetTableCommand") 
+            $Table | Should -Not -Be $null
         }
     }
 
@@ -75,8 +79,8 @@ Describe "AzureRmStorageTable" {
 
             $entity = Get-AzTableRow -table $tableInsert
 
-            $entity.PartitionKey | Should be $expectedPK
-            $entity.RowKey | Should be $expectedRK
+            $entity.PartitionKey | Should -Be $expectedPK
+            $entity.RowKey | Should -Be $expectedRK
         }
 
         It "Can add entity with empty partition key" {
@@ -88,8 +92,8 @@ Describe "AzureRmStorageTable" {
 
             $entity = Get-AzTableRow -table $tableInsert -partitionKey $expectedPK
 
-            $entity.PartitionKey | Should be $expectedPK
-            $entity.RowKey | Should be $expectedRK
+            $entity.PartitionKey | Should -Be $expectedPK
+            $entity.RowKey | Should -Be $expectedRK
         }
 
         It "Can add entity with empty row key" {
@@ -101,8 +105,8 @@ Describe "AzureRmStorageTable" {
 
             $entity = Get-AzTableRow -table $tableInsert -columnName "RowKey" -value $expectedRK -operator Equal
 
-            $entity.PartitionKey | Should be $expectedPK
-            $entity.RowKey | Should be $expectedRK
+            $entity.PartitionKey | Should -Be $expectedPK
+            $entity.RowKey | Should -Be $expectedRK
         }
 
         It "Can add entity with empty partition and row keys" {
@@ -114,8 +118,8 @@ Describe "AzureRmStorageTable" {
 
             $entity = Get-AzTableRow -table $tableInsert -customFilter "(PartitionKey eq '$($expectedPK)') and (RowKey eq '$($expectedRK)')"
 
-            $entity.PartitionKey | Should be $expectedPK
-            $entity.RowKey | Should be $expectedRK
+            $entity.PartitionKey | Should -Be $expectedPK
+            $entity.RowKey | Should -Be $expectedRK
         }
 
         It "Can add entity with properties" {
@@ -129,8 +133,8 @@ Describe "AzureRmStorageTable" {
 
             $entity = Get-AzTableRow -table $tableInsert -customFilter "(PartitionKey eq '$($PK)') and (RowKey eq '$($RK)')"
 
-            $entity.computerName | Should be $expectedProperty1Content
-            $entity.osVersion | Should be $expectedProperty2Content
+            $entity.computerName | Should -Be $expectedProperty1Content
+            $entity.osVersion | Should -Be $expectedProperty2Content
         }
     }
 
@@ -150,36 +154,36 @@ Describe "AzureRmStorageTable" {
             $entityList = $null
             $expectedRowCount = 9
             $entityList = Get-AzTableRow -table $tableInsert
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
 
         It "Can it get specific columns for a specific row" {
             $entity = $null
             $expectedStringValue = "Windows 10"
             $entity = Get-AzTableRow -Table $tableInsert -partitionKey $partitionKey -rowKey $rowKey -SelectColumn @('osVersion', 'computerName')
-            $entity.osVersion | Should be $expectedStringValue
-            $entity.status | Should be $null
+            $entity.osVersion | Should -Be $expectedStringValue
+            $entity.status | Should -Be $null
         }
 
         It "Can it get rows by partition key" {
             $entityList = $null
             $expectedRowCount = 4
             $entityList = Get-AzTableRow -table $tableInsert -partitionKey $partitionKey
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
 
         It "Can it get rows by partition key, limiting the number of results" {
             $entityList = $null
             $expectedRowCount = 2
             $entityList = Get-AzTableRow -table $tableInsert -partitionKey $partitionKey -Top 2
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
 
         It "Can it get row by partition and row key" {
             $entityList = $null
             $expectedRowCount = 1
             $entityList = @(Get-AzTableRow -table $tableInsert -partitionKey $partitionKey -RowKey $rowKey)
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
 
         It "Can it get row by column name using guid value" {
@@ -188,35 +192,35 @@ Describe "AzureRmStorageTable" {
             Add-AzTableRow -table $tableInsert -partitionKey $partitionKey -rowKey ([guid]::NewGuid().tostring())-property @{"computerName"="COMP05";"osVersion"="Windows 10";"status"="OK";"id"=$expectedGuidValue}
 
             $entity = Get-AzTableRow -Table $tableInsert -ColumnName "id" -guidvalue $expectedGuidValue -operator Equal
-            $entity.id | Should be $expectedGuidValue
+            $entity.id | Should -Be $expectedGuidValue
         }
 
         It "Can it get row by column name using string value" {
             $entity = $null
             $expectedStringValue = "COMP02"
             $entity = Get-AzTableRow -Table $tableInsert -ColumnName "computerName" -value $expectedStringValue -operator Equal
-            $entity.computerName | Should be $expectedStringValue
+            $entity.computerName | Should -Be $expectedStringValue
         }
 
         It "Can it get row using custom filter" {
             $entityList = $null
             $expectedRowCount = 1
             $entityList = @(Get-AzTableRow -Table $tableInsert -CustomFilter "(osVersion eq 'Windows XP') and (computerName eq 'COMP04')")
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
 
         It "Can limit the number of results" {
             $entityList = $null
             $expectedRowCount = 5
             $entityList = Get-AzTableRow -table $tableInsert -Top 5
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
 
         It "Doesn't break when there are more rows than TakeCount" {
             $entityList = $null
             $expectedRowCount = 10
             $entityList = Get-AzTableRow -table $tableInsert -Top 86
-            $entityList.Count | Should be $expectedRowCount
+            $entityList.Count | Should -Be $expectedRowCount
         }
     }
 
@@ -233,12 +237,12 @@ Describe "AzureRmStorageTable" {
             Add-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK -property @{}
 
             $entity = Get-AzTableRow -table $tableDelete
-            $entity | Should Not Be $null
+            $entity | Should -Not -Be $null
 
             Remove-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK 
 
             $entity = Get-AzTableRow -table $tableDelete
-            $entity | Should Be $null
+            $entity | Should -Be $null
         }
 
         It "Can delete entity with empty partition key" {
@@ -249,12 +253,12 @@ Describe "AzureRmStorageTable" {
             Add-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK -property @{}
 
             $entity = Get-AzTableRow -table $tableDelete -partitionKey $expectedPK
-            $entity | Should Not Be $null
+            $entity | Should -Not -Be $null
 
             Remove-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK
 
             $entity = Get-AzTableRow -table $tableDelete -partitionKey $PK
-            $entity | Should Be $null
+            $entity | Should -Be $null
         }
 
         It "Can delete entity with empty row key" {
@@ -265,13 +269,13 @@ Describe "AzureRmStorageTable" {
             Add-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK -property @{}
 
             $entity = Get-AzTableRow -table $tableDelete -columnName "RowKey" -value $RK -operator Equal
-            $entity | Should Not Be $null
+            $entity | Should -Not -Be $null
 
             Remove-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK
 
             $entity = Get-AzTableRow -table $tableDelete -columnName "RowKey" -value $RK -operator Equal
 
-            $entity | Should Be $null
+            $entity | Should -Be $null
         }
 
         It "Can delete entity with empty partition and row keys" {
@@ -282,12 +286,12 @@ Describe "AzureRmStorageTable" {
             Add-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK -property @{}
 
             $entity = Get-AzTableRow -table $tableDelete -customFilter "(PartitionKey eq '$($PK)') and (RowKey eq '$($RK)')"
-            $entity | Should Not Be $null
+            $entity | Should -Not -Be $null
 
             Remove-AzTableRow -table $tableDelete -partitionKey $PK -rowKey $RK
 
             $entity = Get-AzTableRow -table $tableDelete -customFilter "(PartitionKey eq '$($PK)') and (RowKey eq '$($RK)')"
-            $entity | Should Be $null
+            $entity | Should -Be $null
         }
     }
     
@@ -301,7 +305,7 @@ Describe "AzureRmStorageTable" {
             
             [string]$filter = [Microsoft.Azure.Cosmos.Table.TableQuery]::GenerateFilterCondition("computerName",[Microsoft.Azure.Cosmos.Table.QueryComparisons]::Equal,"COMP03")
             $UpdateEntity = Get-AzTableRow -table $tableInsert -customFilter $filter
-            $UpdateEntity.status | Should Be $expectedValue
+            $UpdateEntity.status | Should -Be $expectedValue
 
             # Changing values
             $UpdateEntity.osVersion = "Windows 10"
@@ -312,7 +316,7 @@ Describe "AzureRmStorageTable" {
 
             # Getting the entity again to check the changes
             $UpdateEntity = Get-AzTableRow -table $tableInsert -customFilter $filter
-            $UpdateEntity.status | Should Not Be $expectedValue
+            $UpdateEntity.status | Should -Not -Be $expectedValue
         }
     }
 

--- a/Tests/AzureRmStorageTable.Tests.ps1
+++ b/Tests/AzureRmStorageTable.Tests.ps1
@@ -152,12 +152,13 @@ Describe "AzureRmStorageTable" {
             $entity.osVersion | Should -Be $expectedProperty2Content
         }
 
-        It "Can add multiple entities with a batch operation" {
+        It "Can add multiple entities to a batch operation" {
             $batch = New-AzTableBatch
             $PK = [guid]::NewGuid().Guid
 
             $property1Content = "COMP01"
             $property2Content = "Linux"
+            
 
             Add-AzTableRow -Batch $batch -RowKey ([guid]::NewGuid().tostring()) -PartitionKey $PK -Property @{ "computerName" = $property1Content; "osVersion" = $property2Content }
             Add-AzTableRow -Batch $batch -RowKey ([guid]::NewGuid().tostring()) -PartitionKey $PK -Property @{ "computerName" = $property1Content; "osVersion" = $property2Content }

--- a/docs/Add-AzTableRow.md
+++ b/docs/Add-AzTableRow.md
@@ -8,24 +8,40 @@ schema: 2.0.0
 # Add-AzTableRow
 
 ## SYNOPSIS
-Adds a row/entity to a specified table
+Adds a row/entity to a specified table or batch operation
 
 ## SYNTAX
 
+### Table
 ```powershell
-Add-AzTableRow [-Table] <Object> [-PartitionKey] <String> [-RowKey] <String> [[-property] <Hashtable>]
+Add-AzTableRow -Table <Object> -PartitionKey <String> -RowKey <String> [-Property <Hashtable>]
+ [-UpdateExisting] [<CommonParameters>]
+```
+
+### Batch
+```powershell
+Add-AzTableRow -Batch <Object> -PartitionKey <String> -RowKey <String> [-Property <Hashtable>]
  [-UpdateExisting] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Adds a row/entity to a specified table
+Adds a row/entity to a specified table or batch operation
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```powershell
 # Adding a row
-Add-AzTableRow -Table $Table -PartitionKey $PartitionKey -RowKey ([guid]::NewGuid().tostring()) -property @{"firstName"="Paulo";"lastName"="Costa";"role"="presenter"}
+Add-AzTableRow -Table $Table -PartitionKey $PartitionKey -RowKey ([guid]::NewGuid().tostring()) -Property @{"firstName"="Paulo";"lastName"="Costa";"role"="presenter"}
+```
+
+### EXAMPLE 2
+```powershell
+# Adding a row with a batch operation
+$batch = New-AzTableBatch
+$entity = @{"firstName"="Paulo";"lastName"="Costa";"role"="presenter"}
+Add-AzTableRow -Batch $batch -PartitionKey $PartitionKey -RowKey ([guid]::NewGuid().tostring()) -Property $entity
+Invoke-AzTableBatch -Table $Table -Batch $batch
 ```
 
 ## PARAMETERS
@@ -35,7 +51,22 @@ Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entity wi
 
 ```yaml
 Type: Object
-Parameter Sets: (All)
+Parameter Sets: Table
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Batch
+Table batch operation object of type Microsoft.Azure.Cosmos.Table.TableBatchOperation where the entity will be added
+
+```yaml
+Type: Object
+Parameter Sets: Batch
 Aliases:
 
 Required: True
@@ -75,7 +106,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -property
+### -Property
 Hashtable with the columns that will be part of the entity. E.g. `@{"firstName"="Paulo";"lastName"="Marques"}`
 
 ```yaml

--- a/docs/Remove-AzTableRow.md
+++ b/docs/Remove-AzTableRow.md
@@ -14,12 +14,17 @@ Remove-AzTableRow - Removes a specified table row
 
 ### byEntityPSObjectObject
 ```powershell
-Remove-AzTableRow -Table <Object> -entity <Object> [<CommonParameters>]
+Remove-AzTableRow -Table <Object> -Entity <Object> [<CommonParameters>]
 ```
 
 ### byPartitionandRowKeys
 ```powershell
 Remove-AzTableRow -Table <Object> -PartitionKey <String> -RowKey <String> [<CommonParameters>]
+```
+
+### Batch
+```powershell
+Remove-AzTableRow -Batch <Object> -Entity <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,6 +55,18 @@ Remove-AzTableRow -Table $Table -PartitionKey "TableEntityDemoFullList" -RowKey 
 Get-AzTableRowAll -Table $Table | Remove-AzTableRow -Table $Table
 ```
 
+### EXAMPLE 4
+```powershell
+# Deleting an entry with a batch operation
+$batch = New-AzTableBatch
+[string]$Filter1 = [Microsoft.Azure.Cosmos.Table.TableQuery]::GenerateFilterCondition("firstName",[Microsoft.Azure.Cosmos.Table.QueryComparisons]::Equal,"Paulo")
+[string]$Filter2 = [Microsoft.Azure.Cosmos.Table.TableQuery]::GenerateFilterCondition("lastName",[Microsoft.Azure.Cosmos.Table.QueryComparisons]::Equal,"Marques")
+[string]$finalFilter = [Microsoft.Azure.Cosmos.Table.TableQuery]::CombineFilters($Filter1,"and",$Filter2)
+$personToDelete = Get-AzTableRowByCustomFilter -Table $Table -CustomFilter $finalFilter
+$personToDelete | Remove-AzTableRow -Batch $batch
+Invoke-AzTableBatch -Table $Table -Batch $batch
+```
+
 ## PARAMETERS
 
 ### -Table
@@ -57,7 +74,7 @@ Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entity ex
 
 ```yaml
 Type: Object
-Parameter Sets: (All)
+Parameter Sets: byEntityPSObjectObject, byPartitionandRowKeys
 Aliases:
 
 Required: True
@@ -67,12 +84,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -entity
-{{ Fill entity Description }}
+### -Batch
+Table batch operation object of type Microsoft.Azure.Cosmos.Table.TableBatchOperation where the entity will be deleted
 
 ```yaml
 Type: Object
-Parameter Sets: byEntityPSObjectObject
+Parameter Sets: Batch
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Entity
+The entity/row with new values to delete
+
+```yaml
+Type: Object
+Parameter Sets: byEntityPSObjectObject, Batch
 Aliases:
 
 Required: True
@@ -83,7 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -PartitionKey
-{{ Fill PartitionKey Description }}
+Identifies the partition in the table
 
 ```yaml
 Type: String
@@ -98,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -RowKey
-{{ Fill RowKey Description }}
+Identifies a row within a partition
 
 ```yaml
 Type: String

--- a/docs/Update-AzTableRow.md
+++ b/docs/Update-AzTableRow.md
@@ -16,6 +16,10 @@ Updates a table entity or batch operation
 Update-AzTableRow -Table <Object> -Entity <Object> [<CommonParameters>]
 ```
 
+```powershell
+Update-AzTableRow -Batch <Object> -Entity <Object> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Updates a table entity or batch operation.
 To work with this cmdlet, you need first retrieve an entity with one of the Get-AzTableRow cmdlets available and store in an object, change the necessary properties and then perform the update passing this modified entity back, through Pipeline or as argument. Notice that this cmdlet accepts only one entity per execution. This cmdlet cannot update Partition Key and/or RowKey because it uses those two values to locate the entity to update it, if this operation is required please delete the old entity and add the new one with the updated values instead.

--- a/docs/Update-AzTableRow.md
+++ b/docs/Update-AzTableRow.md
@@ -8,16 +8,16 @@ schema: 2.0.0
 # Update-AzTableRow
 
 ## SYNOPSIS
-Updates a table entity
+Updates a table entity or batch operation
 
 ## SYNTAX
 
 ```powershell
-Update-AzTableRow [-Table] <Object> [-entity] <Object> [<CommonParameters>]
+Update-AzTableRow -Table <Object> -Entity <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Updates a table entity.
+Updates a table entity or batch operation.
 To work with this cmdlet, you need first retrieve an entity with one of the Get-AzTableRow cmdlets available and store in an object, change the necessary properties and then perform the update passing this modified entity back, through Pipeline or as argument. Notice that this cmdlet accepts only one entity per execution. This cmdlet cannot update Partition Key and/or RowKey because it uses those two values to locate the entity to update it, if this operation is required please delete the old entity and add the new one with the updated values instead.
 
 ## EXAMPLES
@@ -32,6 +32,18 @@ $person.lastName = "New Last Name"
 $person | Update-AzTableRow -Table $Table
 ```
 
+### EXAMPLE 2
+```powershell
+# Updating an entity with a batch operation
+
+$batch = New-AzTableBatch
+[string]$Filter = [Microsoft.Azure.Cosmos.Table.TableQuery]::GenerateFilterCondition("firstName",[Microsoft.Azure.Cosmos.Table.QueryComparisons]::Equal,"User1")
+$person = Get-AzTableRowByCustomFilter -Table $Table -CustomFilter $Filter
+$person.lastName = "New Last Name"
+$person | Update-AzTableRow -Batch $batch
+Invoke-AzTableBatch -Table $table -Batch $batch
+```
+
 ## PARAMETERS
 
 ### -Table
@@ -39,7 +51,7 @@ Table object of type Microsoft.Azure.Cosmos.Table.CloudTable where the entity ex
 
 ```yaml
 Type: Object
-Parameter Sets: (All)
+Parameter Sets: Table
 Aliases:
 
 Required: True
@@ -49,7 +61,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -entity
+### -Batch
+Table batch operation object of type Microsoft.Azure.Cosmos.Table.TableBatchOperation where the entity will be updated
+
+```yaml
+Type: Object
+Parameter Sets: Batch
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Entity
 The entity/row with new values to perform the update.
 
 ```yaml


### PR DESCRIPTION
# TableBatchOperation Support

Continuing work started by @davidroberts63 in PR #69 

## Summary of changes
### New Class
Added an AzTableBatchOperation class that wraps the [Microsoft.Azure.Cosmos.Table.TableBatchOperation] class.  It keeps a separate instance for each partition of the table, since operating on multiple partitions is not supported in one batch operation.
### Functions
New functions
- New-AzTableBatch
Creates and returns (and optionally populates) a new AzTableBatchOperation class to use with subsequent commands.
- Invoke-AzTableBatch
Iterates over each partition in the AzTableBatchOperation object and invokes the related batch operation

Updated functions
- Add-AzTableRow
- Update-AzTableRow
- Remove-AzTableRow

These functions now support passing an AzTableBatchOperation object instead of a table object
### Tests
New tests for New-AzTableBatch and Invoke-AzTableBatch.  
Updated tests for the existing functions to test batch functionality
### Docs
Updated docs for existing functions and added new docs for New-AzTableBatch and Invoke-AzTableBatch

Hopefully this is helpful.  Please let me know if there's anything you'd like changed.
 
